### PR TITLE
feat(cli): add region validation and error handling for invalid AWS r…

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
+use std::error::Error;
+use std::fmt;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -18,6 +20,76 @@ pub struct Cli {
 
     #[clap(flatten)]
     pub verbose: Verbosity<InfoLevel>,
+}
+
+#[derive(Debug)]
+pub struct InvalidRegionError {
+    pub region: String,
+}
+
+impl fmt::Display for InvalidRegionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Invalid AWS region '{}'. Please use a valid AWS region code (e.g., us-east-1, eu-west-1, ap-northeast-1)",
+            self.region
+        )
+    }
+}
+
+impl Error for InvalidRegionError {}
+
+/// List of valid AWS regions
+/// ref: https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html
+const VALID_AWS_REGIONS: &[&str] = &[
+    "us-east-1",      // US East (N. Virginia)
+    "us-east-2",      // US East (Ohio)
+    "us-west-1",      // US West (N. California)
+    "us-west-2",      // US West (Oregon)
+    "af-south-1",     // Africa (Cape Town)
+    "ap-east-1",      // Asia Pacific (Hong Kong)
+    "ap-south-1",     // Asia Pacific (Mumbai)
+    "ap-south-2",     // Asia Pacific (Hyderabad)
+    "ap-southeast-1", // Asia Pacific (Singapore)
+    "ap-southeast-2", // Asia Pacific (Sydney)
+    "ap-southeast-3", // Asia Pacific (Jakarta)
+    "ap-southeast-4", // Asia Pacific (Melbourne)
+    "ap-northeast-1", // Asia Pacific (Tokyo)
+    "ap-northeast-2", // Asia Pacific (Seoul)
+    "ap-northeast-3", // Asia Pacific (Osaka)
+    "ca-central-1",   // Canada (Central)
+    "ca-west-1",      // Canada (Calgary)
+    "eu-central-1",   // Europe (Frankfurt)
+    "eu-central-2",   // Europe (Zurich)
+    "eu-west-1",      // Europe (Ireland)
+    "eu-west-2",      // Europe (London)
+    "eu-west-3",      // Europe (Paris)
+    "eu-south-1",     // Europe (Milan)
+    "eu-south-2",     // Europe (Spain)
+    "eu-north-1",     // Europe (Stockholm)
+    "il-central-1",   // Israel (Tel Aviv)
+    "me-south-1",     // Middle East (Bahrain)
+    "me-central-1",   // Middle East (UAE)
+    "sa-east-1",      // South America (São Paulo)
+];
+
+/// Validates if the provided region is a valid AWS region
+pub fn validate_region(region: &str) -> Result<(), InvalidRegionError> {
+    if VALID_AWS_REGIONS.contains(&region) {
+        Ok(())
+    } else {
+        Err(InvalidRegionError {
+            region: region.to_string(),
+        })
+    }
+}
+
+impl Cli {
+    /// Validates the CLI arguments
+    pub fn validate(&self) -> Result<(), Box<dyn Error>> {
+        validate_region(&self.region)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -87,5 +159,59 @@ mod tests {
 
         // This test just verifies that the help command can be built without errors
         // We're not checking the actual help text content
+    }
+
+    #[test]
+    fn test_validate_region_valid() {
+        // Test valid regions
+        assert!(validate_region("us-east-1").is_ok());
+        assert!(validate_region("eu-west-1").is_ok());
+        assert!(validate_region("ap-northeast-1").is_ok());
+        assert!(validate_region("ca-central-1").is_ok());
+        assert!(validate_region("sa-east-1").is_ok());
+    }
+
+    #[test]
+    fn test_validate_region_invalid() {
+        // Test invalid regions
+        let result = validate_region("invalid-region");
+        assert!(result.is_err());
+
+        let error = result.unwrap_err();
+        assert_eq!(error.region, "invalid-region");
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid AWS region 'invalid-region'")
+        );
+
+        // Test other invalid regions
+        assert!(validate_region("us-east-3").is_err());
+        assert!(validate_region("eu-west-4").is_err());
+        assert!(validate_region("").is_err());
+        assert!(validate_region("not-a-region").is_err());
+    }
+
+    #[test]
+    fn test_cli_validate_valid_region() {
+        let cli = Cli::parse_from(["spotter", "--region", "us-west-2"]);
+        assert!(cli.validate().is_ok());
+    }
+
+    #[test]
+    fn test_cli_validate_invalid_region() {
+        let cli = Cli::parse_from(["spotter", "--region", "invalid-region"]);
+        let result = cli.validate();
+        assert!(result.is_err());
+
+        let error_message = result.unwrap_err().to_string();
+        assert!(error_message.contains("Invalid AWS region 'invalid-region'"));
+    }
+
+    #[test]
+    fn test_cli_validate_default_region() {
+        let cli = Cli::parse_from(["spotter"]);
+        assert!(cli.validate().is_ok());
+        assert_eq!(cli.region, "us-east-1");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,12 @@ use reqwest::Client;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = cli::Cli::parse();
 
+    // Validate CLI arguments
+    if let Err(e) = cli.validate() {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+
     env_logger::Builder::new()
         .filter_level(cli.verbose.log_level_filter())
         .init();


### PR DESCRIPTION
This pull request introduces AWS region validation to the CLI tool, ensuring that only valid AWS regions are accepted as input. It also includes comprehensive test cases for the new functionality and integrates the validation into the main application flow.

### AWS Region Validation:

* Added `InvalidRegionError` struct and implemented `fmt::Display` and `std::error::Error` traits to provide user-friendly error messages for invalid AWS regions. (`src/cli.rs`, [src/cli.rsR25-R94](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR25-R94))
* Defined a list of valid AWS regions (`VALID_AWS_REGIONS`) and created a `validate_region` function to check if a given region is valid. (`src/cli.rs`, [src/cli.rsR25-R94](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR25-R94))
* Added a `validate` method to the `Cli` struct to validate CLI arguments, including the AWS region. (`src/cli.rs`, [src/cli.rsR25-R94](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR25-R94))

### Test Coverage:

* Added unit tests to verify the functionality of `validate_region` and the `Cli::validate` method. These tests cover both valid and invalid AWS regions, as well as default region handling. (`src/cli.rs`, [src/cli.rsR163-R216](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR163-R216))

### Main Application Integration:

* Integrated AWS region validation into the main application flow. If validation fails, an error message is displayed, and the program exits with a non-zero status. (`src/main.rs`, [src/main.rsR12-R17](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR12-R17))…egions