### PR TITLE
feat: integrate anyhow for error handling and add anyhow dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1353,7 @@ dependencies = [
 name = "spotter"
 version = "0.1.3"
 dependencies = [
+ "anyhow",
  "clap",
  "clap-verbosity-flag",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["kohbis <dev.kohbis@gmail.com>"]
 categories = ["command-line-utilities"]
 
 [dependencies]
+anyhow = "1.0.98"
 clap = { version = "4.5.41", features = ["derive"] }
 clap-verbosity-flag = "3.0.3"
 env_logger = "0.11.8"

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,12 +1,12 @@
+use anyhow::Result;
 use reqwest::Client;
 use serde_json::Value;
-use std::error::Error;
 
 pub const SPOT_ADVISOR_DATA_URL: &str =
     "https://spot-bid-advisor.s3.amazonaws.com/spot-advisor-data.json";
 pub const SPOT_PRICE_DATA_URL: &str = "http://spot-price.s3.amazonaws.com/spot.js";
 
-pub async fn fetch_spot_advisor_data(client: &Client) -> Result<Value, Box<dyn Error>> {
+pub async fn fetch_spot_advisor_data(client: &Client) -> Result<Value> {
     log::info!("Fetching spot advisor data...");
     let url = SPOT_ADVISOR_DATA_URL;
     let response = client.get(url).send().await?;
@@ -73,7 +73,7 @@ pub async fn fetch_spot_advisor_data(client: &Client) -> Result<Value, Box<dyn E
     Ok(data)
 }
 
-pub async fn fetch_spot_price_data(client: &Client) -> Result<Value, Box<dyn Error>> {
+pub async fn fetch_spot_price_data(client: &Client) -> Result<Value> {
     log::info!("Fetching spot price data...");
     let url = SPOT_PRICE_DATA_URL;
     let response = client.get(url).send().await?;

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,7 @@
+use anyhow::Result;
 use prettytable::{Cell, Row, Table};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::error::Error;
 
 #[derive(Clone, Debug)]
 pub struct InstanceInfo {
@@ -19,7 +19,7 @@ pub fn display_spot_data(
     advisor_data: &Value,
     price_data: &Value,
     show_spot_price: bool,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     // Create a table to display the data
     let mut table = Table::new();
 
@@ -520,7 +520,7 @@ mod tests {
 
     // Test display_spot_data with no instance type filter
     #[test]
-    fn test_display_spot_data_no_filter() -> Result<(), Box<dyn Error>> {
+    fn test_display_spot_data_no_filter() -> Result<()> {
         // Redirect stdout to capture the table output
         let stdout = io::stdout();
         let mut _handle = stdout.lock();
@@ -542,7 +542,7 @@ mod tests {
 
     // Test display_spot_data with instance type filter
     #[test]
-    fn test_display_spot_data_with_filter() -> Result<(), Box<dyn Error>> {
+    fn test_display_spot_data_with_filter() -> Result<()> {
         // Create mock data
         let advisor_data = create_mock_advisor_data();
         let price_data = create_mock_price_data();
@@ -558,7 +558,7 @@ mod tests {
 
     // Test display_spot_data with spot price display
     #[test]
-    fn test_display_spot_data_with_spot_price() -> Result<(), Box<dyn Error>> {
+    fn test_display_spot_data_with_spot_price() -> Result<()> {
         // Create mock data
         let advisor_data = create_mock_advisor_data();
         let price_data = create_mock_price_data();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,12 @@ mod aws;
 mod cli;
 mod display;
 
+use anyhow::Result;
 use clap::Parser;
 use reqwest::Client;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     let cli = cli::Cli::parse();
 
     // Validate CLI arguments


### PR DESCRIPTION
This pull request refactors the error handling across the codebase by replacing the use of `Box<dyn Error>` with the `anyhow` crate for more ergonomic and consistent error management. It also removes a custom error type and updates related tests accordingly.

### Error Handling Refactor:

* Added `anyhow` as a dependency in `Cargo.toml` to simplify error handling. (`Cargo.toml`, [Cargo.tomlR12](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R12))
* Replaced `Box<dyn Error>` with `anyhow::Result` in function signatures across multiple files, including `src/aws.rs`, `src/cli.rs`, `src/display.rs`, and `src/main.rs`. (`src/aws.rs`, [[1]](diffhunk://#diff-5e2e69ad103f6876150023c4b80faa31f426770b2689746dafd7643ea6a80113R1-R9) [[2]](diffhunk://#diff-5e2e69ad103f6876150023c4b80faa31f426770b2689746dafd7643ea6a80113L76-R76); `src/cli.rs`, [[3]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR1-L4) [[4]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL77-R72); `src/display.rs`, [[5]](diffhunk://#diff-aab9bd06633e7680dd7ac54f81eb5007b79dde5dbbde9e0613e040edd766e89aR1-L4) [[6]](diffhunk://#diff-aab9bd06633e7680dd7ac54f81eb5007b79dde5dbbde9e0613e040edd766e89aL22-R22); `src/main.rs`, [[7]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR5-R10)

### Removal of Custom Error Type:

* Removed the `InvalidRegionError` struct and its associated `Display` and `Error` trait implementations. Replaced it with `anyhow!` macro for error creation in the `validate_region` function. (`src/cli.rs`, [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL25-L41) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL77-R72)

### Updates to Tests:

* Updated test cases to handle the new error type by working with error messages instead of custom error fields. (`src/cli.rs`, [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL180-R164); `src/display.rs`, [[2]](diffhunk://#diff-aab9bd06633e7680dd7ac54f81eb5007b79dde5dbbde9e0613e040edd766e89aL523-R523) [[3]](diffhunk://#diff-aab9bd06633e7680dd7ac54f81eb5007b79dde5dbbde9e0613e040edd766e89aL545-R545) [[4]](diffhunk://#diff-aab9bd06633e7680dd7ac54f81eb5007b79dde5dbbde9e0613e040edd766e89aL561-R561)